### PR TITLE
bugs fixed removing broken request body and duplicate security response

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           - 1025:1025
 
     env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/artisyn?schema=artisyn_api
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/artisyn
       JWT_SECRET: your-jwt-secret-key
       JWT_EXPIRES_IN: 7d
       NODE_ENV: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           - 1025:1025
 
     env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/artisyn?schema=public
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/artisyn?schema=artisyn_api
       JWT_SECRET: your-jwt-secret-key
       JWT_EXPIRES_IN: 7d
       NODE_ENV: test
@@ -69,4 +69,5 @@ jobs:
           pnpm prisma db seed
 
       - name: Run Tests
-        run: pnpm test
+        run: pnpm test -- --run
+        timeout-minutes: 15

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,6 +8,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 // Enum for user roles

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,7 +8,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 // Enum for user roles

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -486,7 +486,12 @@ describe('Security & Rate Limiting Features', () => {
     it('should not expose server version', async () => {
       const response = await request(app).get('/health');
       const server = response.headers['server'];
-      expect(server).not.toContain('Express');
+      // Server header should either not exist, or not contain version info
+      if (server) {
+        expect(server).not.toContain('Express');
+        expect(server).not.toContain('node');
+        expect(server).not.toContain('version');
+      }
     });
 
     it('should enforce HTTPS in production', async () => {

--- a/src/database/seed.ts
+++ b/src/database/seed.ts
@@ -6,18 +6,15 @@ import { prisma } from 'src/db';
 async function main () {
   console.log('Starting seed...');
 
-  // Clear existing data (in order to respect foreign key constraints)
-  // Delete leaf nodes first (models with foreign keys to other models)
+  // Clear existing data
   await prisma.tip.deleteMany();
   await prisma.review.deleteMany();
-  await prisma.job.deleteMany(); // Jobs reference Applications and Artisans
-  await prisma.application.deleteMany(); // Applications reference Artisans and Users
-  await prisma.artisan.deleteMany(); // Artisans reference Users, Categories, Subcategories, Locations
-  await prisma.curator.deleteMany(); // Curators reference Users
-  await prisma.subcategory.deleteMany(); // Subcategories reference Categories
+  await prisma.artisan.deleteMany();
+  await prisma.subcategory.deleteMany();
   await prisma.category.deleteMany();
-  await prisma.location.deleteMany(); // Locations referenced by Users and Artisans
-  await prisma.user.deleteMany(); // Users must be deleted last
+  await prisma.curator.deleteMany();
+  await prisma.location.deleteMany();
+  await prisma.user.deleteMany();
 
   console.log('Cleared existing data');
 

--- a/src/database/seed.ts
+++ b/src/database/seed.ts
@@ -6,46 +6,55 @@ import { prisma } from 'src/db';
 async function main () {
   console.log('Starting seed...');
 
-  // Clear existing data (in order to respect foreign key constraints)
-  // Delete leaf nodes first (models with foreign keys to other models)
-  // Use try-catch to handle cases where tables might be empty or not exist
-  try {
-    // Level 1: No foreign keys or only reference other leaf nodes
-    await prisma.analyticsEvent.deleteMany();
-    await prisma.dataExportRequest.deleteMany();
-    await prisma.personalAccessToken.deleteMany();
-    await prisma.passwordCodeResets.deleteMany();
-    await prisma.pendingDeletion.deleteMany();
-    await prisma.media.deleteMany();
-    
-    // Level 2: Reference Reviews
-    await prisma.reviewResponse.deleteMany();
-    await prisma.reviewReport.deleteMany();
-    
-    // Level 3: Reference Users and Artisans
-    await prisma.tip.deleteMany();
-    await prisma.review.deleteMany();
-    await prisma.job.deleteMany(); // Jobs reference Applications and Artisans
-    await prisma.application.deleteMany(); // Applications reference Artisans and Users
-    
-    // Level 4: Reference Users, Categories, Locations
-    await prisma.artisan.deleteMany(); // Artisans reference Users, Categories, Subcategories, Locations
-    await prisma.curator.deleteMany(); // Curators reference Users
-    
-    // Level 5: Reference Categories
-    await prisma.subcategory.deleteMany(); // Subcategories reference Categories
-    
-    // Level 6: No foreign keys or standalone
-    await prisma.category.deleteMany();
-    await prisma.location.deleteMany(); // Locations referenced by Users and Artisans
-    
-    // Level 7: Delete last - referenced by almost everything
-    await prisma.user.deleteMany();
-    
-    console.log('Cleared existing data');
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    console.log('Note: Could not clear all data (this is normal for fresh databases):', errorMessage);
+  // Note: When running with `prisma db push --force-reset` in CI,
+  // the database is already clean, so we don't need to delete existing data.
+  // The delete operations below are only needed for local development
+  // when re-running seed on an existing database.
+  
+  // For CI/production with fresh databases, skip deletion entirely
+  if (process.env.NODE_ENV === 'test' || process.env.CI) {
+    console.log('Skipping data deletion (fresh database detected)');
+  } else {
+    // Clear existing data (in order to respect foreign key constraints)
+    // Delete leaf nodes first (models with foreign keys to other models)
+    try {
+      // Level 1: No foreign keys or only reference other leaf nodes
+      await prisma.analyticsEvent.deleteMany();
+      await prisma.dataExportRequest.deleteMany();
+      await prisma.personalAccessToken.deleteMany();
+      await prisma.passwordCodeResets.deleteMany();
+      await prisma.pendingDeletion.deleteMany();
+      await prisma.media.deleteMany();
+      
+      // Level 2: Reference Reviews
+      await prisma.reviewResponse.deleteMany();
+      await prisma.reviewReport.deleteMany();
+      
+      // Level 3: Reference Users and Artisans
+      await prisma.tip.deleteMany();
+      await prisma.review.deleteMany();
+      await prisma.job.deleteMany();
+      await prisma.application.deleteMany();
+      
+      // Level 4: Reference Users, Categories, Locations
+      await prisma.artisan.deleteMany();
+      await prisma.curator.deleteMany();
+      
+      // Level 5: Reference Categories
+      await prisma.subcategory.deleteMany();
+      
+      // Level 6: No foreign keys or standalone
+      await prisma.category.deleteMany();
+      await prisma.location.deleteMany();
+      
+      // Level 7: Delete last - referenced by almost everything
+      await prisma.user.deleteMany();
+      
+      console.log('Cleared existing data');
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.log('Note: Could not clear all data:', errorMessage);
+    }
   }
 
   // Create admin user

--- a/src/database/seed.ts
+++ b/src/database/seed.ts
@@ -6,17 +6,47 @@ import { prisma } from 'src/db';
 async function main () {
   console.log('Starting seed...');
 
-  // Clear existing data
-  await prisma.tip.deleteMany();
-  await prisma.review.deleteMany();
-  await prisma.artisan.deleteMany();
-  await prisma.subcategory.deleteMany();
-  await prisma.category.deleteMany();
-  await prisma.curator.deleteMany();
-  await prisma.location.deleteMany();
-  await prisma.user.deleteMany();
-
-  console.log('Cleared existing data');
+  // Clear existing data (in order to respect foreign key constraints)
+  // Delete leaf nodes first (models with foreign keys to other models)
+  // Use try-catch to handle cases where tables might be empty or not exist
+  try {
+    // Level 1: No foreign keys or only reference other leaf nodes
+    await prisma.analyticsEvent.deleteMany();
+    await prisma.dataExportRequest.deleteMany();
+    await prisma.personalAccessToken.deleteMany();
+    await prisma.passwordCodeResets.deleteMany();
+    await prisma.pendingDeletion.deleteMany();
+    await prisma.media.deleteMany();
+    
+    // Level 2: Reference Reviews
+    await prisma.reviewResponse.deleteMany();
+    await prisma.reviewReport.deleteMany();
+    
+    // Level 3: Reference Users and Artisans
+    await prisma.tip.deleteMany();
+    await prisma.review.deleteMany();
+    await prisma.job.deleteMany(); // Jobs reference Applications and Artisans
+    await prisma.application.deleteMany(); // Applications reference Artisans and Users
+    
+    // Level 4: Reference Users, Categories, Locations
+    await prisma.artisan.deleteMany(); // Artisans reference Users, Categories, Subcategories, Locations
+    await prisma.curator.deleteMany(); // Curators reference Users
+    
+    // Level 5: Reference Categories
+    await prisma.subcategory.deleteMany(); // Subcategories reference Categories
+    
+    // Level 6: No foreign keys or standalone
+    await prisma.category.deleteMany();
+    await prisma.location.deleteMany(); // Locations referenced by Users and Artisans
+    
+    // Level 7: Delete last - referenced by almost everything
+    await prisma.user.deleteMany();
+    
+    console.log('Cleared existing data');
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.log('Note: Could not clear all data (this is normal for fresh databases):', errorMessage);
+  }
 
   // Create admin user
   const adminPassword = await argon2.hash('admin123');

--- a/src/database/seed.ts
+++ b/src/database/seed.ts
@@ -6,15 +6,18 @@ import { prisma } from 'src/db';
 async function main () {
   console.log('Starting seed...');
 
-  // Clear existing data
+  // Clear existing data (in order to respect foreign key constraints)
+  // Delete leaf nodes first (models with foreign keys to other models)
   await prisma.tip.deleteMany();
   await prisma.review.deleteMany();
-  await prisma.artisan.deleteMany();
-  await prisma.subcategory.deleteMany();
+  await prisma.job.deleteMany(); // Jobs reference Applications and Artisans
+  await prisma.application.deleteMany(); // Applications reference Artisans and Users
+  await prisma.artisan.deleteMany(); // Artisans reference Users, Categories, Subcategories, Locations
+  await prisma.curator.deleteMany(); // Curators reference Users
+  await prisma.subcategory.deleteMany(); // Subcategories reference Categories
   await prisma.category.deleteMany();
-  await prisma.curator.deleteMany();
-  await prisma.location.deleteMany();
-  await prisma.user.deleteMany();
+  await prisma.location.deleteMany(); // Locations referenced by Users and Artisans
+  await prisma.user.deleteMany(); // Users must be deleted last
 
   console.log('Cleared existing data');
 

--- a/src/middleware/securityHeaders.ts
+++ b/src/middleware/securityHeaders.ts
@@ -32,24 +32,14 @@ export const securityHeadersMiddleware = (req: Request, res: Response, next: Nex
   // Strict-Transport-Security - Enforce HTTPS
   res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
 
-  // Remove X-Powered-By header
+  // Remove identifying headers to prevent fingerprinting
   res.removeHeader('X-Powered-By');
-
-  // Remove Server header
   res.removeHeader('Server');
-
-  // Set a custom server header without version info
-  res.setHeader('Server', 'Artisyn-API');
 
   // Prevent caching of sensitive data
   res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
   res.setHeader('Pragma', 'no-cache');
   res.setHeader('Expires', '0');
-
-  // Additional security headers
-  res.setHeader('X-Content-Type-Options', 'nosniff');
-  res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
 
   next();
 };
@@ -129,36 +119,6 @@ export const preventParameterPollutionMiddleware = (req: Request, res: Response,
     console.error('Parameter pollution prevention error:', error);
     next();
   }
-};
-
-/**
- * Middleware to validate request body size
- */
-export const validateBodySizeMiddleware = (maxSize: number = 10 * 1024 * 1024) => {
-  return (req: Request, res: Response, next: NextFunction) => {
-    let size = 0;
-
-    req.on('data', (chunk: Buffer) => {
-      size += chunk.length;
-
-      if (size > maxSize) {
-        req.destroy();
-        return res.status(413).json({
-          success: false,
-          message: `Request body too large. Maximum size: ${maxSize / 1024 / 1024}MB`,
-        });
-      }
-    });
-
-    req.on('end', () => {
-      next();
-    });
-
-    req.on('error', (error) => {
-      console.error('Body size validation error:', error);
-      next();
-    });
-  };
 };
 
 /**

--- a/src/utils/initialize.ts
+++ b/src/utils/initialize.ts
@@ -76,10 +76,10 @@ export const initialize = async (app: Express) => {
   // request-processing behavior and makes middleware ordering harder to reason about.
 
   // Parse application/json
-  app.use(express.json());
+  app.use(express.json({ limit: '10mb' }));
 
   // Parse application/x-www-form-urlencoded (for non-multipart forms)
-  app.use(express.urlencoded({ extended: true }));
+  app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
   // ===== SECURITY MIDDLEWARE =====
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,11 +5,12 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
 
   test: {
-    retry: 10,
+    retry: 2,
     root: './',
     passWithNoTests: true,
     environment: 'node',
     include: ['**/__tests__/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    testTimeout: 60000,
     env: {
       NODE_ENV: 'test',
     },


### PR DESCRIPTION
The entire "Additional security headers" block (lines 49–52) was eliminated, and the X-Powered-By / Server removal was consolidated under a single comment.

Removed — validateBodySizeMiddleware from securityHeaders.ts. It was:
Never imported or mounted anywhere
Fundamentally incompatible with the existing express.json() / express.urlencoded() body parsers (both consume the same readable stream)
Would silently fail or crash if actually used
Added — limit: '10mb' to both body parsers in initialize.ts

closes #114 

closes #115