### PR TITLE
fix: resolve security issues #116, #117, #118

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -777,6 +777,35 @@ model AuditLog {
   @@map("audit_logs")
 }
 
+// Enum for API key status
+enum APIKeyStatus {
+  active
+  revoked
+  expired
+}
+
+// API Key model for persistent API key management
+model APIKey {
+  id               String       @id @default(uuid())
+  key              String       @unique // Hashed key
+  name             String
+  description      String?
+  userId           String?
+  status           APIKeyStatus @default(active)
+  rateLimit        Int          @default(1000)
+  expiresAt        DateTime?
+  lastUsedAt       DateTime?
+  ipWhitelist      String[]     @default([])
+  allowedEndpoints String[]     @default([])
+  createdAt        DateTime     @default(now())
+  updatedAt        DateTime     @updatedAt
+
+  @@index([key])
+  @@index([userId])
+  @@index([status])
+  @@map("api_keys")
+}
+
 // Data Export Request model - for GDPR data export functionality
 model DataExportRequest {
   id           String                  @id @default(uuid())

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -3,6 +3,7 @@ import { blockIP, getBlockedIPs, ipBlockingMiddleware, isIPBlocked, unblockIP } 
 import { checkRateLimit, cleanupRateLimit, createRateLimiter, rateLimitConfigs, registerBypassToken, revokeBypassToken } from '../middleware/rateLimiter';
 import { createAPIKey, hashAPIKey, revokeAPIKey, verifyAPIKey } from '../services/apiKeyService';
 import { createAlert, getAlertStatistics, getRecentAlerts, resolveAlert } from '../services/monitoringService';
+import { exportLogsToFile, isValidLogFileName } from '../utils/securityLogging';
 import express, { Express } from 'express';
 
 import request from 'supertest';
@@ -507,6 +508,46 @@ describe('Security & Rate Limiting Features', () => {
       const hash2 = hashAPIKey('password123');
       expect(hash1).toBe(hash2); // Consistent hashing
       expect(hash1.length).toBeGreaterThan(32); // Long hash
+    });
+  });
+
+  describe('Log Filename Sanitization Tests (Issue #116)', () => {
+    it('should accept valid filenames', () => {
+      expect(isValidLogFileName('security_logs_2024.log')).toBe(true);
+      expect(isValidLogFileName('export-2024-01-01.json')).toBe(true);
+      expect(isValidLogFileName('logs.txt')).toBe(true);
+      expect(isValidLogFileName('my file.log')).toBe(true);
+    });
+
+    it('should reject path traversal attempts', () => {
+      expect(isValidLogFileName('../etc/passwd')).toBe(false);
+      expect(isValidLogFileName('../../secret')).toBe(false);
+      expect(isValidLogFileName('logs/../../etc/passwd')).toBe(false);
+    });
+
+    it('should reject filenames with slashes', () => {
+      expect(isValidLogFileName('/etc/passwd')).toBe(false);
+      expect(isValidLogFileName('subdir/file.log')).toBe(false);
+    });
+
+    it('should reject empty or non-string filenames', () => {
+      expect(isValidLogFileName('')).toBe(false);
+      expect(isValidLogFileName(null as any)).toBe(false);
+      expect(isValidLogFileName(undefined as any)).toBe(false);
+    });
+
+    it('should reject filenames with null bytes', () => {
+      expect(isValidLogFileName('file\x00.log')).toBe(false);
+    });
+
+    it('should return false from exportLogsToFile for unsafe filenames', () => {
+      const result = exportLogsToFile('../etc/passwd');
+      expect(result).toBe(false);
+    });
+
+    it('should return false from exportLogsToFile for path traversal', () => {
+      const result = exportLogsToFile('../../outside.log');
+      expect(result).toBe(false);
     });
   });
 });

--- a/src/middleware/ipBlocking.ts
+++ b/src/middleware/ipBlocking.ts
@@ -1,7 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
 
-import { prisma } from '../db';
-
 /**
  * In-memory store for blocked IPs
  * Structure: { ip: { blockedUntil: number, reason: string } }
@@ -200,54 +198,9 @@ export const startIPBlockingCleanup = () => {
 };
 
 /**
- * Store blocked IP in database for persistence
+ * NOTE: IP blocking is intentionally in-memory only.
+ * Blocked IPs do not persist across process restarts.
+ * This is a deliberate design choice for simplicity and performance.
+ * If persistence is required in the future, add an IPBlock model to the
+ * Prisma schema and implement the appropriate DB calls here.
  */
-export const persistBlockedIP = async (ip: string, reason: string, durationMs: number) => {
-  try {
-    // Create IP block record (requires IPBlock model in Prisma)
-    // await prisma.ipBlock.create({
-    //   data: {
-    //     ip,
-    //     reason,
-    //     blockedUntil: new Date(Date.now() + durationMs),
-    //   },
-    // });
-    if (process.env.NODE_ENV !== 'test') {
-      console.log(`[IP Blocking] IP ${ip} blocked: ${reason}`);
-    }
-  } catch (error) {
-
-    if (process.env.NODE_ENV !== 'test') {
-      console.error('Error persisting blocked IP:', error);
-    }
-  }
-};
-
-/**
- * Load previously blocked IPs from database
- */
-export const loadBlockedIPsFromDB = async () => {
-  try {
-    // Load IP blocks from database on startup
-    // const blocks = await prisma.ipBlock.findMany({
-    //   where: {
-    //     blockedUntil: {
-    //       gt: new Date(),
-    //     },
-    //   },
-    // });
-    // blocks.forEach(block => {
-    //   blockedIPs.set(block.ip, {
-    //     blockedUntil: block.blockedUntil.getTime(),
-    //     reason: block.reason,
-    //   });
-    // });
-    if (process.env.NODE_ENV !== 'test') {
-      console.log('[IP Blocking] Loaded blocked IPs from database');
-    }
-  } catch (error) {
-    if (process.env.NODE_ENV !== 'test') {
-      console.error('Error loading blocked IPs:', error);
-    }
-  }
-};

--- a/src/services/apiKeyService.ts
+++ b/src/services/apiKeyService.ts
@@ -76,20 +76,20 @@ export const createAPIKey = async (
   // Store in cache
   apiKeyCache.set(hashedKey, apiKey);
 
-  // Optionally store in database (requires APIKey model in Prisma)
+  // Persist to database
   try {
-    // await prisma.apiKey.create({
-    //   data: {
-    //     id,
-    //     key: hashedKey,
-    //     name,
-    //     description,
-    //     userId,
-    //     status: 'active',
-    //     rateLimit,
-    //     expiresAt,
-    //   },
-    // });
+    await prisma.aPIKey.create({
+      data: {
+        id,
+        key: hashedKey,
+        name,
+        description,
+        userId,
+        status: 'active',
+        rateLimit,
+        expiresAt,
+      },
+    });
     console.log(`[API Key] Created new API key: ${name}`);
   } catch (error) {
     console.error('Error creating API key in database:', error);
@@ -113,17 +113,30 @@ export const verifyAPIKey = async (key: string): Promise<APIKey | null> => {
 
   if (!apiKey) {
     // Load from database if not in cache
-    // try {
-    //   const dbKey = await prisma.apiKey.findUnique({
-    //     where: { key: hashedKey },
-    //   });
-    //   if (dbKey) {
-    //     apiKey = dbKey as any;
-    //     apiKeyCache.set(hashedKey, apiKey);
-    //   }
-    // } catch (error) {
-    //   console.error('Error verifying API key:', error);
-    // }
+    try {
+      const dbKey = await prisma.aPIKey.findUnique({
+        where: { key: hashedKey },
+      });
+      if (dbKey) {
+        apiKey = {
+          id: dbKey.id,
+          key: dbKey.key,
+          name: dbKey.name,
+          description: dbKey.description ?? undefined,
+          userId: dbKey.userId ?? undefined,
+          status: dbKey.status as APIKey['status'],
+          rateLimit: dbKey.rateLimit,
+          createdAt: dbKey.createdAt,
+          expiresAt: dbKey.expiresAt ?? undefined,
+          lastUsedAt: dbKey.lastUsedAt ?? undefined,
+          ipWhitelist: dbKey.ipWhitelist,
+          allowedEndpoints: dbKey.allowedEndpoints,
+        };
+        apiKeyCache.set(hashedKey, apiKey);
+      }
+    } catch (error) {
+      console.error('Error verifying API key:', error);
+    }
   }
 
   if (!apiKey) {
@@ -156,11 +169,15 @@ export const revokeAPIKey = async (keyId: string): Promise<boolean> => {
         key.status = 'revoked';
         apiKeyCache.set(hash, key);
 
-        // Update in database
-        // await prisma.apiKey.update({
-        //   where: { id: keyId },
-        //   data: { status: 'revoked' },
-        // });
+        // Update in database (best-effort; cache is source of truth for active session)
+        try {
+          await prisma.aPIKey.update({
+            where: { id: keyId },
+            data: { status: 'revoked' },
+          });
+        } catch (dbError) {
+          console.error('Error updating revoked API key in database:', dbError);
+        }
 
         console.log(`[API Key] Revoked API key: ${key.name}`);
         return true;
@@ -184,14 +201,28 @@ export const getAPIKeyInfo = async (keyId: string): Promise<APIKey | null> => {
   }
 
   // Try to load from database
-  // try {
-  //   const dbKey = await prisma.apiKey.findUnique({
-  //     where: { id: keyId },
-  //   });
-  //   return dbKey as any;
-  // } catch (error) {
-  //   console.error('Error getting API key info:', error);
-  // }
+  try {
+    const dbKey = await prisma.aPIKey.findUnique({
+      where: { id: keyId },
+    });
+    if (!dbKey) return null;
+    return {
+      id: dbKey.id,
+      key: dbKey.key,
+      name: dbKey.name,
+      description: dbKey.description ?? undefined,
+      userId: dbKey.userId ?? undefined,
+      status: dbKey.status as APIKey['status'],
+      rateLimit: dbKey.rateLimit,
+      createdAt: dbKey.createdAt,
+      expiresAt: dbKey.expiresAt ?? undefined,
+      lastUsedAt: dbKey.lastUsedAt ?? undefined,
+      ipWhitelist: dbKey.ipWhitelist,
+      allowedEndpoints: dbKey.allowedEndpoints,
+    };
+  } catch (error) {
+    console.error('Error getting API key info:', error);
+  }
 
   return null;
 };
@@ -268,21 +299,35 @@ export const requireAPIKey = (req: Request, res: Response, next: NextFunction) =
 export const loadAPIKeysFromDB = async () => {
   try {
     // Load active API keys from database
-    // const keys = await prisma.apiKey.findMany({
-    //   where: {
-    //     status: 'active',
-    //     OR: [
-    //       { expiresAt: null },
-    //       { expiresAt: { gt: new Date() } },
-    //     ],
-    //   },
-    // });
+    const keys = await prisma.aPIKey.findMany({
+      where: {
+        status: 'active',
+        OR: [
+          { expiresAt: null },
+          { expiresAt: { gt: new Date() } },
+        ],
+      },
+    });
 
-    // keys.forEach(key => {
-    //   apiKeyCache.set(key.key, key as any);
-    // });
+    keys.forEach(dbKey => {
+      const apiKey: APIKey = {
+        id: dbKey.id,
+        key: dbKey.key,
+        name: dbKey.name,
+        description: dbKey.description ?? undefined,
+        userId: dbKey.userId ?? undefined,
+        status: dbKey.status as APIKey['status'],
+        rateLimit: dbKey.rateLimit,
+        createdAt: dbKey.createdAt,
+        expiresAt: dbKey.expiresAt ?? undefined,
+        lastUsedAt: dbKey.lastUsedAt ?? undefined,
+        ipWhitelist: dbKey.ipWhitelist,
+        allowedEndpoints: dbKey.allowedEndpoints,
+      };
+      apiKeyCache.set(dbKey.key, apiKey);
+    });
 
-    console.log('[API Key] Loaded API keys from database');
+    console.log(`[API Key] Loaded ${keys.length} API keys from database`);
   } catch (error) {
     console.error('Error loading API keys from database:', error);
   }
@@ -301,10 +346,10 @@ export const cleanupExpiredAPIKeys = async () => {
         apiKeyCache.set(hash, key);
 
         // Update in database
-        // await prisma.apiKey.update({
-        //   where: { id: key.id },
-        //   data: { status: 'expired' },
-        // });
+        await prisma.aPIKey.update({
+          where: { id: key.id },
+          data: { status: 'expired' },
+        });
       }
     }
 

--- a/src/utils/initialize.ts
+++ b/src/utils/initialize.ts
@@ -2,7 +2,6 @@ import express, { Express } from "express";
 import { facebookStrategy, googleStrategy } from "./passport";
 import {
   ipBlockingMiddleware,
-  loadBlockedIPsFromDB,
   recordFailedAttemptMiddleware,
   startIPBlockingCleanup,
 } from "src/middleware/ipBlocking";
@@ -153,7 +152,6 @@ export const initialize = async (app: Express) => {
 
   startRateLimitCleanup();
   startIPBlockingCleanup();
-  await loadBlockedIPsFromDB();
   startMonitoringScheduler();
   startLogCleanupScheduler();
   startAnalyticsScheduler();

--- a/src/utils/securityLogging.ts
+++ b/src/utils/securityLogging.ts
@@ -262,14 +262,37 @@ export const getLogsForTimeRange = (startTime: Date, endTime: Date): SecurityLog
 };
 
 /**
+ * Validate a log export filename.
+ * Accepts only alphanumeric characters, hyphens, underscores, and dots.
+ * Rejects path traversal sequences and absolute paths.
+ */
+export const isValidLogFileName = (fileName: string): boolean => {
+  if (!fileName || typeof fileName !== 'string') return false;
+  // Allow only safe filename characters; no slashes, no null bytes, no traversal
+  return /^[\w\-. ]+$/.test(fileName) && !fileName.includes('..');
+};
+
+/**
  * Export logs to file
  */
 export const exportLogsToFile = (fileName: string, logs: SecurityLog[] = logStore): boolean => {
   try {
-    const filePath = path.join(logsDir, fileName);
+    if (!isValidLogFileName(fileName)) {
+      console.error(`[Logging] Rejected unsafe filename: ${fileName}`);
+      return false;
+    }
+
+    // Resolve the final path and verify it stays within logsDir
+    const resolvedLogsDir = path.resolve(logsDir);
+    const filePath = path.resolve(resolvedLogsDir, fileName);
+    if (!filePath.startsWith(resolvedLogsDir + path.sep) && filePath !== resolvedLogsDir) {
+      console.error(`[Logging] Path traversal attempt detected: ${fileName}`);
+      return false;
+    }
+
     // Ensure logs directory exists for exports
-    if (!fs.existsSync(logsDir)) {
-      fs.mkdirSync(logsDir, { recursive: true });
+    if (!fs.existsSync(resolvedLogsDir)) {
+      fs.mkdirSync(resolvedLogsDir, { recursive: true });
     }
     const content = logs.map(log => JSON.stringify(log)).join('\n');
     fs.writeFileSync(filePath, content);


### PR DESCRIPTION
## Summary

Resolves three security issues assigned to LaGodxy in the Stellar Wave wave.

## Changes

### Issue #116 — Sanitize Exported Security Log Filenames
- Added `isValidLogFileName()` that validates filenames against a safe allowlist pattern (`/^[\w\-. ]+$/`)
- `exportLogsToFile()` now rejects filenames with path traversal sequences (`../`), slashes, null bytes, or empty values
- Added a secondary check: resolves the final path and verifies it stays within `logsDir` before writing
- Added 7 new tests covering valid filenames, path traversal attempts, slashes, null bytes, and empty inputs

### Issue #117 — Persist API Keys in the Database
- Added `APIKey` model to `prisma/schema.prisma` with `APIKeyStatus` enum (`active`, `revoked`, `expired`)
- Uncommented Prisma DB calls in `createAPIKey()`, `verifyAPIKey()`, `revokeAPIKey()`, `getAPIKeyInfo()`, `loadAPIKeysFromDB()`, and `cleanupExpiredAPIKeys()`
- DB calls are wrapped in try/catch so failures are logged but don't break the in-memory cache path (important for test environments without a DB)
- The schema change will be applied via `prisma db push` in CI

### Issue #118 — Remove Misleading IP Blocking DB Hooks
- Removed `persistBlockedIP()` and `loadBlockedIPsFromDB()` stub functions from `ipBlocking.ts`
- Removed unused `prisma` import from `ipBlocking.ts`
- Removed `await loadBlockedIPsFromDB()` call from `initialize.ts` startup sequence (it was a no-op that implied false durability)
- Added a documentation comment clarifying that IP blocking is intentionally in-memory only

## Testing

- All 51 tests in `src/__tests__/security.test.ts` pass ✅
- 7 new filename sanitization tests added for issue #116
- Existing API key tests continue to pass (DB errors are caught gracefully)

Closes #116
Closes #117
Closes #118