### PR TITLE
fix: resolve issues #127 and #128 (yusuftomilola)

### DIFF
--- a/src/__tests__/preferences-privacy.test.ts
+++ b/src/__tests__/preferences-privacy.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { notificationValidationRules } from '../utils/profileValidators';
+
+describe('Notification validation rules (issue #128)', () => {
+  it('defines digestFrequency with allowed enum values', () => {
+    const rules = notificationValidationRules.digestFrequency as string[];
+    expect(rules).toBeDefined();
+    const enumRule = rules.find(r => typeof r === 'string' && r.startsWith('in:')) as string;
+    expect(enumRule).toContain('daily');
+    expect(enumRule).toContain('weekly');
+    expect(enumRule).toContain('monthly');
+    expect(enumRule).toContain('never');
+  });
+
+  it('includes boolean rules for all notification flags', () => {
+    const fields = ['emailNotifications', 'pushNotifications', 'smsNotifications', 'marketingEmails', 'activityEmails'] as const;
+    for (const field of fields) {
+      expect(notificationValidationRules[field] as string[]).toContain('boolean');
+    }
+  });
+
+  it('does not expose non-notification preference fields', () => {
+    const rules = notificationValidationRules as Record<string, unknown>;
+    expect(rules.theme).toBeUndefined();
+    expect(rules.language).toBeUndefined();
+    expect(rules.currencyPreference).toBeUndefined();
+  });
+});
+
+describe('Unblock user safety (issue #127)', () => {
+  it('filters an empty block list without error', () => {
+    const blockList: string[] = [];
+    expect(blockList.filter(id => id !== 'user-xyz')).toEqual([]);
+  });
+
+  it('removes the correct user from the block list', () => {
+    const blockList = ['user-a', 'user-b', 'user-c'];
+    expect(blockList.filter(id => id !== 'user-b')).toEqual(['user-a', 'user-c']);
+  });
+
+  it('returns the list unchanged when the user was not blocked', () => {
+    const blockList = ['user-a', 'user-b'];
+    expect(blockList.filter(id => id !== 'user-z')).toEqual(['user-a', 'user-b']);
+  });
+});

--- a/src/controllers/PreferencesController.ts
+++ b/src/controllers/PreferencesController.ts
@@ -4,7 +4,7 @@ import BaseController from "./BaseController";
 import { RequestError } from 'src/utils/errors';
 import UserPreferencesResource from "src/resources/UserPreferencesResource";
 import { logAuditEvent } from 'src/utils/auditLogger';
-import { preferencesValidationRules } from 'src/utils/profileValidators';
+import { notificationValidationRules, preferencesValidationRules } from 'src/utils/profileValidators';
 import { prisma } from 'src/db';
 
 /**
@@ -91,26 +91,14 @@ export default class extends BaseController {
         const userId = req.user?.id;
         RequestError.assertFound(userId, 'Unauthorized', 401);
 
-        const notificationPrefs: any = {
-            emailNotifications: req.body.emailNotifications,
-            pushNotifications: req.body.pushNotifications,
-            smsNotifications: req.body.smsNotifications,
-            marketingEmails: req.body.marketingEmails,
-            activityEmails: req.body.activityEmails,
-            digestFrequency: req.body.digestFrequency,
-        };
-
-        // Filter out undefined values
-        Object.keys(notificationPrefs).forEach((key: string) =>
-            notificationPrefs[key] === undefined && delete notificationPrefs[key]
-        );
+        const data = await this.validateAsync(req, notificationValidationRules);
 
         const preferences = await prisma.userPreferences.upsert({
             where: { userId },
-            update: notificationPrefs,
+            update: data,
             create: {
                 userId,
-                ...notificationPrefs,
+                ...data,
             },
         });
 

--- a/src/controllers/PrivacySettingsController.ts
+++ b/src/controllers/PrivacySettingsController.ts
@@ -219,9 +219,10 @@ export default class extends BaseController {
             const blockList = privacySettings?.blockList || [];
             const updatedBlockList = blockList.filter((id: string) => id !== blockedUserId);
 
-            const updated = await prisma.privacySettings.update({
+            const updated = await prisma.privacySettings.upsert({
                 where: { userId },
-                data: { blockList: updatedBlockList },
+                update: { blockList: updatedBlockList },
+                create: { userId, blockList: updatedBlockList },
             });
 
             // Log unblock action

--- a/src/utils/profileValidators.ts
+++ b/src/utils/profileValidators.ts
@@ -56,6 +56,18 @@ export const preferencesValidationRules: InitialRules = {
 };
 
 /**
+ * Validation rules for Notification Preferences
+ */
+export const notificationValidationRules: InitialRules = {
+    emailNotifications: ['boolean'],
+    pushNotifications: ['boolean'],
+    smsNotifications: ['boolean'],
+    marketingEmails: ['boolean'],
+    activityEmails: ['boolean'],
+    digestFrequency: ['string', 'in:daily,weekly,monthly,never'],
+};
+
+/**
  * Validation rules for Privacy Settings
  */
 export const privacySettingsValidationRules: InitialRules = {


### PR DESCRIPTION
## Summary

This PR addresses two issues in the preferences and privacy settings controllers.

## Issues

closes #127
closes #128

## Changes

**#128 - Notification preference validation** (`src/utils/profileValidators.ts`, `src/controllers/PreferencesController.ts`): Added `notificationValidationRules` with explicit rules for all notification fields including a `digestFrequency` enum guard. `updateNotifications` now runs `validateAsync` instead of forwarding raw `req.body` values directly to Prisma, matching the validation behaviour of the full preferences endpoint.

**#127 - Unblock user safety** (`src/controllers/PrivacySettingsController.ts`): Changed `prisma.privacySettings.update` to `prisma.privacySettings.upsert` in `unblockUser`. For first-time users with no existing privacy settings row, the endpoint now creates the row with an empty block list and returns a stable success response instead of failing.

**Tests** (`src/__tests__/preferences-privacy.test.ts`): Vitest coverage for the notification validation rules structure and the block list filter logic.