### PR TITLE
Enforce privacy settings at runtime and expand data export/deletion test coverage

### DIFF
--- a/src/controllers/ProfileController.ts
+++ b/src/controllers/ProfileController.ts
@@ -9,6 +9,7 @@ import { logAuditEvent } from 'src/utils/auditLogger';
 import { prisma } from 'src/db';
 import { normalizeSocialLinks, profileValidationRules } from 'src/utils/profileValidators';
 import { PrivacyService } from 'src/services/PrivacyService';
+import { PrivacyGuard } from 'src/services/PrivacyGuard';
 
 /**
  * UserProfileController - Manages user profile CRUD operations
@@ -267,6 +268,10 @@ export default class extends BaseController {
                     isPublicView: true,
                 },
             });
+
+            // Enforce searchEngineIndexing: tell crawlers whether to index this profile
+            const robotsDirective = await PrivacyGuard.getRobotsDirective(String(targetUserId));
+            res.setHeader('X-Robots-Tag', robotsDirective);
 
             res.status(200).json({
                 status: 'success',

--- a/src/controllers/__tests__/data-export-http.test.ts
+++ b/src/controllers/__tests__/data-export-http.test.ts
@@ -1,0 +1,583 @@
+/**
+ * HTTP integration tests for data-export and account-deletion endpoints.
+ *
+ * Covers all seven routes wired in src/routes/api.ts:
+ *   POST   /api/data-export/request
+ *   GET    /api/data-export/requests
+ *   GET    /api/data-export/:requestId/status
+ *   GET    /api/data-export/:requestId/download
+ *   POST   /api/data-export/:requestId/cancel
+ *   POST   /api/account/deletion-request
+ *   POST   /api/account/cancel-deletion
+ *
+ * Focus: route wiring, auth enforcement, status codes, response envelopes,
+ * pagination, authorization isolation, and deletion lifecycle.
+ */
+
+import fs from 'node:fs/promises';
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import argon2 from 'argon2';
+import { faker } from '@faker-js/faker';
+
+import app from 'src/index';
+import { prisma } from 'src/db';
+import { generateAccessToken } from 'src/utils/helpers';
+import { DataExportService } from 'src/services/DataExportService';
+import * as mailer from 'src/mailer/mailer';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createUser(suffix: string) {
+    const plainPassword = 'Password123#';
+    const user = await prisma.user.create({
+        data: {
+            email: `http-export-${suffix}@example.com`,
+            password: await argon2.hash(plainPassword),
+            firstName: 'Http',
+            lastName: 'Test',
+        },
+    });
+
+    const { token } = generateAccessToken({
+        username: user.email,
+        id: user.id,
+        index: faker.number.int({ min: 1, max: 999999 }),
+    });
+
+    return { user, token, plainPassword };
+}
+
+function authHeaders(token: string) {
+    return { Authorization: `Bearer ${token}` };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('Data Export & Account Deletion — HTTP integration', () => {
+    let owner: Awaited<ReturnType<typeof createUser>>;
+    let intruder: Awaited<ReturnType<typeof createUser>>;
+
+    beforeAll(async () => {
+        vi.spyOn(mailer, 'sendMail').mockResolvedValue(null);
+
+        const runId = faker.string.alphanumeric(8).toLowerCase();
+        owner = await createUser(`owner-${runId}`);
+        intruder = await createUser(`intruder-${runId}`);
+    });
+
+    afterEach(async () => {
+        await prisma.dataExportRequest.deleteMany({
+            where: { userId: { in: [owner.user.id, intruder.user.id] } },
+        });
+        await prisma.pendingDeletion.deleteMany({
+            where: { userId: { in: [owner.user.id, intruder.user.id] } },
+        });
+    });
+
+    afterAll(async () => {
+        vi.restoreAllMocks();
+        await prisma.user.deleteMany({
+            where: { id: { in: [owner.user.id, intruder.user.id] } },
+        });
+    });
+
+    // =======================================================================
+    // POST /api/data-export/request
+    // =======================================================================
+
+    describe('POST /api/data-export/request', () => {
+        it('returns 401 when unauthenticated', async () => {
+            const res = await request(app).post('/api/data-export/request').send({ format: 'json' });
+            expect(res.status).toBe(401);
+        });
+
+        it('creates a pending export and returns 201 with correct envelope', async () => {
+            const res = await request(app)
+                .post('/api/data-export/request')
+                .set(authHeaders(owner.token))
+                .send({ format: 'json' });
+
+            expect(res.status).toBe(201);
+            expect(res.body.status).toBe('success');
+            expect(res.body.code).toBe(201);
+            expect(res.body.data).toMatchObject({
+                userId: owner.user.id,
+                format: 'json',
+                status: 'pending',
+            });
+        });
+
+        it('defaults to json format when no format provided', async () => {
+            const res = await request(app)
+                .post('/api/data-export/request')
+                .set(authHeaders(owner.token))
+                .send({});
+
+            expect(res.status).toBe(201);
+            expect(res.body.data.format).toBe('json');
+        });
+
+        it('accepts csv format', async () => {
+            const res = await request(app)
+                .post('/api/data-export/request')
+                .set(authHeaders(owner.token))
+                .send({ format: 'csv' });
+
+            expect(res.status).toBe(201);
+            expect(res.body.data.format).toBe('csv');
+        });
+
+        it('returns 422 for unsupported format', async () => {
+            const res = await request(app)
+                .post('/api/data-export/request')
+                .set(authHeaders(owner.token))
+                .send({ format: 'xml' });
+
+            expect(res.status).toBe(422);
+            expect(res.body.status).toBe('error');
+        });
+
+        it('returns 429 when a non-expired request exists within 24 hours', async () => {
+            // First request succeeds
+            await request(app)
+                .post('/api/data-export/request')
+                .set(authHeaders(owner.token))
+                .send({ format: 'json' })
+                .expect(201);
+
+            // Second request within the same 24-hour window should be rejected
+            const res = await request(app)
+                .post('/api/data-export/request')
+                .set(authHeaders(owner.token))
+                .send({ format: 'json' });
+
+            expect(res.status).toBe(429);
+        });
+    });
+
+    // =======================================================================
+    // GET /api/data-export/requests
+    // =======================================================================
+
+    describe('GET /api/data-export/requests', () => {
+        it('returns 401 when unauthenticated', async () => {
+            const res = await request(app).get('/api/data-export/requests');
+            expect(res.status).toBe(401);
+        });
+
+        it('returns a paginated list of the user\'s own requests', async () => {
+            // Seed two requests for owner
+            await prisma.dataExportRequest.createMany({
+                data: [
+                    { userId: owner.user.id, format: 'json', status: 'pending' },
+                    { userId: owner.user.id, format: 'csv', status: 'pending' },
+                ],
+            });
+
+            const res = await request(app)
+                .get('/api/data-export/requests')
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(200);
+            expect(res.body.status).toBe('success');
+            expect(Array.isArray(res.body.data)).toBe(true);
+            expect(res.body.data.length).toBeGreaterThanOrEqual(2);
+            expect(res.body.pagination).toBeDefined();
+            expect(typeof res.body.pagination.total).toBe('number');
+        });
+
+        it('does not return requests belonging to other users', async () => {
+            await prisma.dataExportRequest.create({
+                data: { userId: intruder.user.id, format: 'json', status: 'pending' },
+            });
+
+            const res = await request(app)
+                .get('/api/data-export/requests')
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(200);
+            const ids = res.body.data.map((r: any) => r.userId);
+            expect(ids.every((id: string) => id === owner.user.id)).toBe(true);
+        });
+
+        it('respects ?take and ?skip pagination parameters', async () => {
+            await prisma.dataExportRequest.createMany({
+                data: Array.from({ length: 3 }, () => ({
+                    userId: owner.user.id,
+                    format: 'json' as const,
+                    status: 'pending' as const,
+                })),
+            });
+
+            const res = await request(app)
+                .get('/api/data-export/requests?limit=2&page=1')
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(200);
+            expect(res.body.data.length).toBeLessThanOrEqual(2);
+        });
+    });
+
+    // =======================================================================
+    // GET /api/data-export/:requestId/status
+    // =======================================================================
+
+    describe('GET /api/data-export/:requestId/status', () => {
+        it('returns 401 when unauthenticated', async () => {
+            const res = await request(app).get('/api/data-export/fake-id/status');
+            expect(res.status).toBe(401);
+        });
+
+        it('returns 200 with status details for an owned request', async () => {
+            const exportRequest = await prisma.dataExportRequest.create({
+                data: { userId: owner.user.id, format: 'json', status: 'pending' },
+            });
+
+            const res = await request(app)
+                .get(`/api/data-export/${exportRequest.id}/status`)
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(200);
+            expect(res.body.data.id).toBe(exportRequest.id);
+            expect(res.body.data.status).toBe('pending');
+        });
+
+        it('returns 404 for a non-existent request', async () => {
+            const res = await request(app)
+                .get('/api/data-export/00000000-0000-0000-0000-000000000000/status')
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(404);
+        });
+
+        it('returns 404 when requesting another user\'s export (authorization isolation)', async () => {
+            const intruderRequest = await prisma.dataExportRequest.create({
+                data: { userId: intruder.user.id, format: 'json', status: 'pending' },
+            });
+
+            const res = await request(app)
+                .get(`/api/data-export/${intruderRequest.id}/status`)
+                .set(authHeaders(owner.token)); // owner trying to see intruder's request
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    // =======================================================================
+    // GET /api/data-export/:requestId/download
+    // =======================================================================
+
+    describe('GET /api/data-export/:requestId/download', () => {
+        it('returns 401 when unauthenticated', async () => {
+            const res = await request(app).get('/api/data-export/fake-id/download');
+            expect(res.status).toBe(401);
+        });
+
+        it('returns 400 when the export is not yet ready', async () => {
+            const exportRequest = await prisma.dataExportRequest.create({
+                data: { userId: owner.user.id, format: 'json', status: 'pending' },
+            });
+
+            const res = await request(app)
+                .get(`/api/data-export/${exportRequest.id}/download`)
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(400);
+            expect(res.body.message).toMatch(/not ready/i);
+        });
+
+        it('returns 410 when the download link has expired', async () => {
+            const exportRequest = await prisma.dataExportRequest.create({
+                data: {
+                    userId: owner.user.id,
+                    format: 'json',
+                    status: 'ready',
+                    downloadUrl: DataExportService.getDownloadUrl('test'),
+                    expiresAt: new Date(Date.now() - 1000), // already expired
+                },
+            });
+
+            const res = await request(app)
+                .get(`/api/data-export/${exportRequest.id}/download`)
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(410);
+        });
+
+        it('streams the file when the export is ready and file exists', async () => {
+            // Produce a real export file via the service
+            const exportRequest = await prisma.dataExportRequest.create({
+                data: { userId: owner.user.id, format: 'json', status: 'pending' },
+            });
+
+            await new (await import('src/services/DataExportService')).DataExportService().processRequest(exportRequest.id);
+
+            const readyRequest = await prisma.dataExportRequest.findUnique({ where: { id: exportRequest.id } });
+            if (readyRequest?.status !== 'ready') return; // if processing failed in CI, skip
+
+            const res = await request(app)
+                .get(`/api/data-export/${exportRequest.id}/download`)
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(200);
+
+            // Cleanup file
+            await fs
+                .unlink(DataExportService.getExportFilePath(exportRequest.id, 'json'))
+                .catch(() => undefined);
+        });
+
+        it('returns 404 when attempting to download another user\'s export', async () => {
+            const intruderRequest = await prisma.dataExportRequest.create({
+                data: {
+                    userId: intruder.user.id,
+                    format: 'json',
+                    status: 'ready',
+                    downloadUrl: 'https://external.example.com/file.json',
+                },
+            });
+
+            const res = await request(app)
+                .get(`/api/data-export/${intruderRequest.id}/download`)
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    // =======================================================================
+    // POST /api/data-export/:requestId/cancel
+    // =======================================================================
+
+    describe('POST /api/data-export/:requestId/cancel', () => {
+        it('returns 401 when unauthenticated', async () => {
+            const res = await request(app).post('/api/data-export/fake-id/cancel');
+            expect(res.status).toBe(401);
+        });
+
+        it('cancels a pending export and returns 200', async () => {
+            const exportRequest = await prisma.dataExportRequest.create({
+                data: { userId: owner.user.id, format: 'json', status: 'pending' },
+            });
+
+            const res = await request(app)
+                .post(`/api/data-export/${exportRequest.id}/cancel`)
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(200);
+            expect(res.body.data.status).toBe('expired');
+        });
+
+        it('cancels a processing export and returns 200', async () => {
+            const exportRequest = await prisma.dataExportRequest.create({
+                data: { userId: owner.user.id, format: 'json', status: 'processing' },
+            });
+
+            const res = await request(app)
+                .post(`/api/data-export/${exportRequest.id}/cancel`)
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(200);
+        });
+
+        it('returns 400 when trying to cancel a ready export', async () => {
+            const exportRequest = await prisma.dataExportRequest.create({
+                data: {
+                    userId: owner.user.id,
+                    format: 'json',
+                    status: 'ready',
+                    downloadUrl: 'https://example.com/x.json',
+                },
+            });
+
+            const res = await request(app)
+                .post(`/api/data-export/${exportRequest.id}/cancel`)
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 400 when trying to cancel an already-expired request', async () => {
+            const exportRequest = await prisma.dataExportRequest.create({
+                data: { userId: owner.user.id, format: 'json', status: 'expired' },
+            });
+
+            const res = await request(app)
+                .post(`/api/data-export/${exportRequest.id}/cancel`)
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 404 when cancelling another user\'s request (authorization)', async () => {
+            const intruderRequest = await prisma.dataExportRequest.create({
+                data: { userId: intruder.user.id, format: 'json', status: 'pending' },
+            });
+
+            const res = await request(app)
+                .post(`/api/data-export/${intruderRequest.id}/cancel`)
+                .set(authHeaders(owner.token));
+
+            expect(res.status).toBe(404);
+        });
+    });
+
+    // =======================================================================
+    // POST /api/account/deletion-request
+    // =======================================================================
+
+    describe('POST /api/account/deletion-request', () => {
+        it('returns 401 when unauthenticated', async () => {
+            const res = await request(app)
+                .post('/api/account/deletion-request')
+                .send({ password: owner.plainPassword });
+            expect(res.status).toBe(401);
+        });
+
+        it('returns 400 when password is missing', async () => {
+            const res = await request(app)
+                .post('/api/account/deletion-request')
+                .set(authHeaders(owner.token))
+                .send({});
+            expect(res.status).toBe(400);
+        });
+
+        it('returns 401 when password is incorrect', async () => {
+            const res = await request(app)
+                .post('/api/account/deletion-request')
+                .set(authHeaders(owner.token))
+                .send({ password: 'WrongPassword!' });
+            expect(res.status).toBe(401);
+        });
+
+        it('schedules deletion and returns 202 with scheduledAt', async () => {
+            const res = await request(app)
+                .post('/api/account/deletion-request')
+                .set(authHeaders(owner.token))
+                .send({ password: owner.plainPassword });
+
+            expect(res.status).toBe(202);
+            expect(res.body.status).toBe('success');
+            expect(res.body.data.status).toBe('pending_deletion');
+            expect(res.body.data.scheduledAt).toBeDefined();
+
+            // Confirm the pending deletion record exists
+            const pending = await prisma.pendingDeletion.findUnique({
+                where: { userId: owner.user.id },
+            });
+            expect(pending).not.toBeNull();
+        });
+
+        it('returns 409 when a deletion is already pending', async () => {
+            // First request
+            await request(app)
+                .post('/api/account/deletion-request')
+                .set(authHeaders(owner.token))
+                .send({ password: owner.plainPassword })
+                .expect(202);
+
+            // Duplicate request
+            const res = await request(app)
+                .post('/api/account/deletion-request')
+                .set(authHeaders(owner.token))
+                .send({ password: owner.plainPassword });
+
+            expect(res.status).toBe(409);
+        });
+    });
+
+    // =======================================================================
+    // POST /api/account/cancel-deletion
+    // =======================================================================
+
+    describe('POST /api/account/cancel-deletion', () => {
+        it('returns 401 when unauthenticated', async () => {
+            const res = await request(app).post('/api/account/cancel-deletion').send({});
+            expect(res.status).toBe(401);
+        });
+
+        it('returns 404 when no pending deletion exists', async () => {
+            const res = await request(app)
+                .post('/api/account/cancel-deletion')
+                .set(authHeaders(owner.token))
+                .send({});
+            expect(res.status).toBe(404);
+        });
+
+        it('cancels a pending deletion in-app and returns 200', async () => {
+            // Schedule deletion first
+            await request(app)
+                .post('/api/account/deletion-request')
+                .set(authHeaders(owner.token))
+                .send({ password: owner.plainPassword })
+                .expect(202);
+
+            // Cancel it in-app (no token in body)
+            const res = await request(app)
+                .post('/api/account/cancel-deletion')
+                .set(authHeaders(owner.token))
+                .send({});
+
+            expect(res.status).toBe(200);
+            expect(res.body.data.status).toBe('deletion_cancelled');
+
+            // Confirm the record is gone
+            const pending = await prisma.pendingDeletion.findUnique({
+                where: { userId: owner.user.id },
+            });
+            expect(pending).toBeNull();
+        });
+
+        it('cancels a pending deletion via email token and returns 200', async () => {
+            await request(app)
+                .post('/api/account/deletion-request')
+                .set(authHeaders(owner.token))
+                .send({ password: owner.plainPassword })
+                .expect(202);
+
+            const record = await prisma.pendingDeletion.findUnique({
+                where: { userId: owner.user.id },
+            });
+
+            const res = await request(app)
+                .post('/api/account/cancel-deletion')
+                .set(authHeaders(owner.token))
+                .send({ token: record!.token });
+
+            expect(res.status).toBe(200);
+        });
+
+        it('returns 403 when the token belongs to a different user', async () => {
+            // Schedule deletion for intruder
+            await request(app)
+                .post('/api/account/deletion-request')
+                .set(authHeaders(intruder.token))
+                .send({ password: intruder.plainPassword })
+                .expect(202);
+
+            const intruderRecord = await prisma.pendingDeletion.findUnique({
+                where: { userId: intruder.user.id },
+            });
+
+            // Owner tries to cancel intruder's deletion via token
+            const res = await request(app)
+                .post('/api/account/cancel-deletion')
+                .set(authHeaders(owner.token))
+                .send({ token: intruderRecord!.token });
+
+            expect(res.status).toBe(403);
+
+            // Intruder's record must still exist
+            const stillPending = await prisma.pendingDeletion.findUnique({
+                where: { userId: intruder.user.id },
+            });
+            expect(stillPending).not.toBeNull();
+        });
+    });
+});

--- a/src/services/DataRetentionJob.ts
+++ b/src/services/DataRetentionJob.ts
@@ -1,0 +1,116 @@
+import { prisma } from 'src/db';
+import { logAuditEvent } from 'src/utils/auditLogger';
+
+/**
+ * DataRetentionJob — enforces per-user dataRetentionMonths privacy settings.
+ *
+ * Covered data domains (matching what DataExportService exports):
+ *   • auditLogs    — operational log trail
+ *   • reviews      — reviews written by the user
+ *   • sentTips     — tips sent by the user
+ *
+ * The job is intentionally non-destructive for the User record itself;
+ * use the GDPR deletion flow (pendingDeletion / DeletionPurgeJob) for
+ * full account erasure.
+ */
+export class DataRetentionJob {
+    /**
+     * Run retention enforcement for all users that have a custom policy.
+     * Call this from a nightly cron/scheduler.
+     */
+    static async run(): Promise<RetentionRunSummary> {
+        const summary: RetentionRunSummary = { usersProcessed: 0, errors: [] };
+
+        // Only fetch users who have explicitly configured a retention policy.
+        // Users without a PrivacySettings row (or with the default 24-month value)
+        // are skipped — they can be handled by a separate system-wide sweep if needed.
+        const settings = await prisma.privacySettings.findMany({
+            select: { userId: true, dataRetentionMonths: true },
+        });
+
+        for (const { userId, dataRetentionMonths } of settings) {
+            try {
+                await this.enforceForUser(userId, dataRetentionMonths);
+                summary.usersProcessed++;
+            } catch (error) {
+                summary.errors.push({
+                    userId,
+                    message: error instanceof Error ? error.message : String(error),
+                });
+            }
+        }
+
+        return summary;
+    }
+
+    /**
+     * Apply the retention policy for a single user.
+     * Exported so it can be called directly in tests and from controllers
+     * that want to trigger an immediate sweep (e.g. after a policy update).
+     */
+    static async enforceForUser(
+        userId: string,
+        dataRetentionMonths: number,
+    ): Promise<UserRetentionResult> {
+        const cutoff = new Date();
+        cutoff.setMonth(cutoff.getMonth() - dataRetentionMonths);
+
+        const [deletedAuditLogs, deletedReviews, deletedSentTips] = await Promise.all([
+            prisma.auditLog.deleteMany({
+                where: { userId, createdAt: { lt: cutoff } },
+            }),
+            prisma.review.deleteMany({
+                where: { authorId: userId, createdAt: { lt: cutoff } },
+            }),
+            prisma.tip.deleteMany({
+                where: { senderId: userId, createdAt: { lt: cutoff } },
+            }),
+        ]);
+
+        const result: UserRetentionResult = {
+            userId,
+            cutoff,
+            deleted: {
+                auditLogs: deletedAuditLogs.count,
+                reviews: deletedReviews.count,
+                sentTips: deletedSentTips.count,
+            },
+        };
+
+        const totalDeleted =
+            result.deleted.auditLogs +
+            result.deleted.reviews +
+            result.deleted.sentTips;
+
+        if (totalDeleted > 0) {
+            await logAuditEvent(userId, 'PRIVACY_CHANGE', {
+                entityType: 'DataRetention',
+                entityId: userId,
+                statusCode: 200,
+                metadata: {
+                    action: 'retention_sweep',
+                    dataRetentionMonths,
+                    cutoff: cutoff.toISOString(),
+                    deleted: result.deleted,
+                },
+            });
+        }
+
+        return result;
+    }
+}
+
+export interface UserRetentionResult {
+    userId: string;
+    cutoff: Date;
+    deleted: {
+        auditLogs: number;
+        reviews: number;
+        sentTips: number;
+    };
+}
+
+export interface RetentionRunSummary {
+    usersProcessed: number;
+    errors: Array<{ userId: string; message: string }>;
+}

--- a/src/services/PrivacyGuard.ts
+++ b/src/services/PrivacyGuard.ts
@@ -1,0 +1,101 @@
+import { prisma } from "src/db";
+
+/**
+ * PrivacyGuard — enforces flag-based privacy controls at runtime.
+ *
+ * Each guard returns a structured result rather than throwing, so callers
+ * can decide the appropriate HTTP response (403, 404, silent discard, etc.).
+ *
+ * Flags covered
+ * ─────────────
+ * • searchEngineIndexing  — controls X-Robots-Tag header on public profile responses
+ * • allowDirectMessages   — gate on any endpoint that sends a message to a user
+ * • allowProfileComments  — gate on any endpoint that posts a comment on a user's profile
+ */
+export class PrivacyGuard {
+  /**
+   * Returns the value to set on the X-Robots-Tag response header for a
+   * user's public-facing profile page.
+   *
+   * When searchEngineIndexing is false the profile must carry
+   * `X-Robots-Tag: noindex, nofollow` so search engines do not crawl it.
+   */
+  static async getRobotsDirective(userId: string): Promise<string> {
+    const settings = await prisma.privacySettings.findFirst({
+      where: { userId },
+      select: { searchEngineIndexing: true },
+    });
+
+    if (settings === null || settings.searchEngineIndexing) {
+      return "index, follow";
+    }
+    return "noindex, nofollow";
+  }
+
+  /**
+   * Returns whether `senderId` is permitted to send a direct message to
+   * `targetUserId`.
+   *
+   * Enforcement rules
+   *   1. Users can always message themselves (edge-case / admin tools).
+   *   2. If the target has no PrivacySettings row, messages are allowed (safe default).
+   *   3. Otherwise, the flag value is authoritative.
+   */
+  static async canSendDirectMessage(
+    senderId: string,
+    targetUserId: string,
+  ): Promise<PrivacyCheckResult> {
+    if (senderId === targetUserId) {
+      return { allowed: true };
+    }
+
+    const settings = await prisma.privacySettings.findFirst({
+      where: { userId: targetUserId },
+      select: { allowDirectMessages: true },
+    });
+
+    if (settings === null || settings.allowDirectMessages) {
+      return { allowed: true };
+    }
+
+    return {
+      allowed: false,
+      reason: "This user does not accept direct messages.",
+    };
+  }
+
+  /**
+   * Returns whether `commenterId` is permitted to post a comment on
+   * `targetUserId`'s profile.
+   *
+   * Same default-allow logic as canSendDirectMessage.
+   */
+  static async canPostProfileComment(
+    commenterId: string,
+    targetUserId: string,
+  ): Promise<PrivacyCheckResult> {
+    if (commenterId === targetUserId) {
+      return { allowed: true };
+    }
+
+    const settings = await prisma.privacySettings.findFirst({
+      where: { userId: targetUserId },
+      select: { allowProfileComments: true },
+    });
+
+    if (settings === null || settings.allowProfileComments) {
+      return { allowed: true };
+    }
+
+    return {
+      allowed: false,
+      reason: "This user has disabled profile comments.",
+    };
+  }
+}
+
+export interface PrivacyCheckResult {
+  allowed: boolean;
+  /** Human-readable reason returned to the caller when allowed === false */
+  reason?: string;
+}

--- a/src/services/__tests__/DataRetentionJob.test.ts
+++ b/src/services/__tests__/DataRetentionJob.test.ts
@@ -1,0 +1,246 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { prisma } from 'src/db';
+import { DataRetentionJob } from 'src/services/DataRetentionJob';
+
+/**
+ * Returns a Date that is `months` months in the past, minus one day —
+ * so it falls clearly before any retention cutoff computed during the test.
+ */
+function monthsAgo(months: number): Date {
+    const d = new Date();
+    d.setMonth(d.getMonth() - months);
+    d.setDate(d.getDate() - 1);
+    return d;
+}
+
+describe('DataRetentionJob', () => {
+    let userId: string;
+    let otherUserId: string;
+
+    beforeAll(async () => {
+        const runId = Date.now();
+
+        const user = await prisma.user.create({
+            data: {
+                email: `retention-test-${runId}@example.com`,
+                password: 'hashed',
+                firstName: 'Retention',
+                lastName: 'Test',
+            },
+        });
+        userId = user.id;
+
+        // A second user whose data must NEVER be touched
+        const other = await prisma.user.create({
+            data: {
+                email: `retention-other-${runId}@example.com`,
+                password: 'hashed',
+                firstName: 'Other',
+                lastName: 'User',
+            },
+        });
+        otherUserId = other.id;
+    });
+
+    afterEach(async () => {
+        // Clean up data rows created during each test
+        await prisma.auditLog.deleteMany({ where: { userId: { in: [userId, otherUserId] } } });
+        await prisma.review.deleteMany({ where: { authorId: { in: [userId, otherUserId] } } });
+        await prisma.tip.deleteMany({ where: { senderId: { in: [userId, otherUserId] } } });
+        await prisma.privacySettings.deleteMany({ where: { userId: { in: [userId, otherUserId] } } });
+    });
+
+    afterAll(async () => {
+        await prisma.user.deleteMany({ where: { id: { in: [userId, otherUserId] } } });
+    });
+
+    // -----------------------------------------------------------------------
+    // enforceForUser — core unit behaviour
+    // -----------------------------------------------------------------------
+
+    it('deletes audit logs older than the retention cutoff', async () => {
+        // Seed one old and one recent audit log
+        await prisma.auditLog.createMany({
+            data: [
+                { userId, action: 'PRIVACY_CHANGE', createdAt: monthsAgo(13) },
+                { userId, action: 'PRIVACY_CHANGE', createdAt: new Date() },
+            ],
+        });
+
+        const beforeJob = new Date();
+        const result = await DataRetentionJob.enforceForUser(userId, 12);
+
+        expect(result.deleted.auditLogs).toBe(1);
+
+        // Exclude the audit row written by enforceForUser's own logAuditEvent call
+        const remaining = await prisma.auditLog.findMany({
+            where: { userId, createdAt: { lt: beforeJob } },
+        });
+        expect(remaining).toHaveLength(1);
+    });
+
+    it('deletes reviews authored by the user that are past the cutoff', async () => {
+        const curator = await prisma.user.create({
+            data: {
+                email: `curator-${Date.now()}@example.com`,
+                password: 'hashed',
+                firstName: 'C',
+                lastName: 'U',
+            },
+        });
+
+        try {
+            await prisma.review.createMany({
+                data: [
+                    { authorId: userId, targetId: curator.id, rating: 4, createdAt: monthsAgo(7) },
+                    { authorId: userId, targetId: curator.id, rating: 5, createdAt: new Date() },
+                ],
+            });
+
+            const result = await DataRetentionJob.enforceForUser(userId, 6);
+
+            expect(result.deleted.reviews).toBe(1);
+
+            const remaining = await prisma.review.findMany({ where: { authorId: userId } });
+            expect(remaining).toHaveLength(1);
+        } finally {
+            await prisma.review.deleteMany({ where: { authorId: userId } });
+            await prisma.user.delete({ where: { id: curator.id } });
+        }
+    });
+
+    it('deletes tips sent by the user that are past the cutoff', async () => {
+        const receiver = await prisma.user.create({
+            data: {
+                email: `receiver-${Date.now()}@example.com`,
+                password: 'hashed',
+                firstName: 'R',
+                lastName: 'V',
+            },
+        });
+
+        try {
+            await prisma.tip.createMany({
+                data: [
+                    {
+                        senderId: userId,
+                        receiverId: receiver.id,
+                        amount: 1,
+                        currency: 'ETH',
+                        status: 'PENDING',
+                        createdAt: monthsAgo(4),
+                    },
+                    {
+                        senderId: userId,
+                        receiverId: receiver.id,
+                        amount: 2,
+                        currency: 'ETH',
+                        status: 'PENDING',
+                        createdAt: new Date(),
+                    },
+                ],
+            });
+
+            const result = await DataRetentionJob.enforceForUser(userId, 3);
+
+            expect(result.deleted.sentTips).toBe(1);
+
+            const remaining = await prisma.tip.findMany({ where: { senderId: userId } });
+            expect(remaining).toHaveLength(1);
+        } finally {
+            await prisma.tip.deleteMany({ where: { senderId: userId } });
+            await prisma.user.delete({ where: { id: receiver.id } });
+        }
+    });
+
+    it('does not delete data that is within the retention window', async () => {
+        await prisma.auditLog.create({
+            data: { userId, action: 'PRIVACY_CHANGE', createdAt: new Date() },
+        });
+
+        const result = await DataRetentionJob.enforceForUser(userId, 12);
+
+        expect(result.deleted.auditLogs).toBe(0);
+        expect(result.deleted.reviews).toBe(0);
+        expect(result.deleted.sentTips).toBe(0);
+    });
+
+    it('does not touch data belonging to other users', async () => {
+        await prisma.auditLog.create({
+            data: { userId: otherUserId, action: 'PRIVACY_CHANGE', createdAt: monthsAgo(24) },
+        });
+
+        // Enforce only for userId (not otherUserId)
+        await DataRetentionJob.enforceForUser(userId, 1);
+
+        const otherLogs = await prisma.auditLog.findMany({ where: { userId: otherUserId } });
+        expect(otherLogs).toHaveLength(1);
+    });
+
+    it('returns the correct cutoff date in the result', async () => {
+        const before = new Date();
+        const result = await DataRetentionJob.enforceForUser(userId, 6);
+        const after = new Date();
+
+        // The cutoff should be roughly 6 months ago
+        const sixMonthsAgo = new Date();
+        sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+
+        // Use calendar-month arithmetic to match what enforceForUser does internally
+        const expectedLow = new Date(before);
+        expectedLow.setMonth(expectedLow.getMonth() - 6);
+        expectedLow.setSeconds(expectedLow.getSeconds() - 2); // 2s tolerance
+        const expectedHigh = new Date(after);
+        expectedHigh.setMonth(expectedHigh.getMonth() - 6);
+        expectedHigh.setSeconds(expectedHigh.getSeconds() + 2);
+
+        expect(result.cutoff.getTime()).toBeGreaterThanOrEqual(expectedLow.getTime());
+        expect(result.cutoff.getTime()).toBeLessThanOrEqual(expectedHigh.getTime());
+    });
+
+    // -----------------------------------------------------------------------
+    // run() — batch sweep honours each user's individual policy
+    // -----------------------------------------------------------------------
+
+    it('run() sweeps old data for all users with privacy settings', async () => {
+        // Give both users a 1-month retention policy
+        await prisma.privacySettings.createMany({
+            data: [
+                { userId, dataRetentionMonths: 1 },
+                { userId: otherUserId, dataRetentionMonths: 1 },
+            ],
+        });
+
+        // Seed old audit logs for both
+        await prisma.auditLog.createMany({
+            data: [
+                { userId, action: 'PRIVACY_CHANGE', createdAt: monthsAgo(3) },
+                { userId: otherUserId, action: 'PRIVACY_CHANGE', createdAt: monthsAgo(3) },
+            ],
+        });
+
+        const beforeSweep = new Date();
+        const summary = await DataRetentionJob.run();
+
+        // At least our two users must have been processed
+        expect(summary.usersProcessed).toBeGreaterThanOrEqual(2);
+
+        // Errors from unrelated CI users (orphaned PrivacySettings rows, etc.) are
+        // acceptable — we only care that OUR two users were not among the errors.
+        const ourErrors = summary.errors.filter(
+            (e) => e.userId === userId || e.userId === otherUserId,
+        );
+        expect(ourErrors).toHaveLength(0);
+
+        // Seeded rows (before the sweep) must be gone
+        const remainingUser = await prisma.auditLog.findMany({
+            where: { userId, createdAt: { lt: beforeSweep } },
+        });
+        const remainingOther = await prisma.auditLog.findMany({
+            where: { userId: otherUserId, createdAt: { lt: beforeSweep } },
+        });
+        expect(remainingUser).toHaveLength(0);
+        expect(remainingOther).toHaveLength(0);
+    });
+});

--- a/src/services/__tests__/PrivacyGuard.test.ts
+++ b/src/services/__tests__/PrivacyGuard.test.ts
@@ -1,0 +1,219 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { prisma } from 'src/db';
+import { PrivacyGuard } from 'src/services/PrivacyGuard';
+import app from 'src/index';
+import request from 'supertest';
+import { generateAccessToken } from 'src/utils/helpers';
+import { faker } from '@faker-js/faker';
+
+describe('PrivacyGuard', () => {
+    let userId: string;
+    let otherUserId: string;
+
+    beforeAll(async () => {
+        const runId = faker.string.alphanumeric(8).toLowerCase();
+
+        const user = await prisma.user.create({
+            data: {
+                email: `guard-${runId}@example.com`,
+                password: 'hashed',
+                firstName: 'Guard',
+                lastName: 'Test',
+            },
+        });
+        userId = user.id;
+
+        const other = await prisma.user.create({
+            data: {
+                email: `guard-other-${runId}@example.com`,
+                password: 'hashed',
+                firstName: 'Other',
+                lastName: 'Guard',
+            },
+        });
+        otherUserId = other.id;
+    });
+
+    afterEach(async () => {
+        await prisma.privacySettings.deleteMany({
+            where: { userId: { in: [userId, otherUserId] } },
+        });
+    });
+
+    afterAll(async () => {
+        await prisma.user.deleteMany({ where: { id: { in: [userId, otherUserId] } } });
+    });
+
+    // -----------------------------------------------------------------------
+    // searchEngineIndexing
+    // -----------------------------------------------------------------------
+
+    describe('getRobotsDirective (searchEngineIndexing)', () => {
+        it('returns "index, follow" when searchEngineIndexing is true (default)', async () => {
+            await prisma.privacySettings.create({
+                data: { userId, searchEngineIndexing: true },
+            });
+
+            const directive = await PrivacyGuard.getRobotsDirective(userId);
+            expect(directive).toBe('index, follow');
+        });
+
+        it('returns "noindex, nofollow" when searchEngineIndexing is false', async () => {
+            await prisma.privacySettings.create({
+                data: { userId, searchEngineIndexing: false },
+            });
+
+            const directive = await PrivacyGuard.getRobotsDirective(userId);
+            expect(directive).toBe('noindex, nofollow');
+        });
+
+        it('defaults to "index, follow" when no privacy settings row exists', async () => {
+            const directive = await PrivacyGuard.getRobotsDirective(userId);
+            expect(directive).toBe('index, follow');
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // allowDirectMessages
+    // -----------------------------------------------------------------------
+
+    describe('canSendDirectMessage (allowDirectMessages)', () => {
+        it('allows direct messages when the flag is true (default)', async () => {
+            await prisma.privacySettings.create({
+                data: { userId, allowDirectMessages: true },
+            });
+
+            const result = await PrivacyGuard.canSendDirectMessage(otherUserId, userId);
+            expect(result.allowed).toBe(true);
+        });
+
+        it('blocks direct messages when the flag is false', async () => {
+            await prisma.privacySettings.create({
+                data: { userId, allowDirectMessages: false },
+            });
+
+            const result = await PrivacyGuard.canSendDirectMessage(otherUserId, userId);
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toBeTruthy();
+        });
+
+        it('always allows a user to message themselves', async () => {
+            await prisma.privacySettings.create({
+                data: { userId, allowDirectMessages: false },
+            });
+
+            const result = await PrivacyGuard.canSendDirectMessage(userId, userId);
+            expect(result.allowed).toBe(true);
+        });
+
+        it('defaults to allowed when no privacy settings row exists', async () => {
+            const result = await PrivacyGuard.canSendDirectMessage(otherUserId, userId);
+            expect(result.allowed).toBe(true);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // allowProfileComments
+    // -----------------------------------------------------------------------
+
+    describe('canPostProfileComment (allowProfileComments)', () => {
+        it('allows comments when the flag is true (default)', async () => {
+            await prisma.privacySettings.create({
+                data: { userId, allowProfileComments: true },
+            });
+
+            const result = await PrivacyGuard.canPostProfileComment(otherUserId, userId);
+            expect(result.allowed).toBe(true);
+        });
+
+        it('blocks comments when the flag is false', async () => {
+            await prisma.privacySettings.create({
+                data: { userId, allowProfileComments: false },
+            });
+
+            const result = await PrivacyGuard.canPostProfileComment(otherUserId, userId);
+            expect(result.allowed).toBe(false);
+            expect(result.reason).toBeTruthy();
+        });
+
+        it('always allows the profile owner to comment on their own profile', async () => {
+            await prisma.privacySettings.create({
+                data: { userId, allowProfileComments: false },
+            });
+
+            const result = await PrivacyGuard.canPostProfileComment(userId, userId);
+            expect(result.allowed).toBe(true);
+        });
+
+        it('defaults to allowed when no privacy settings row exists', async () => {
+            const result = await PrivacyGuard.canPostProfileComment(otherUserId, userId);
+            expect(result.allowed).toBe(true);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // HTTP integration: X-Robots-Tag header on public profile endpoint
+    // -----------------------------------------------------------------------
+
+    describe('GET /api/profile/:userId/public — X-Robots-Tag enforcement', () => {
+        let profileUserId: string;
+        let token: string;
+
+        beforeAll(async () => {
+            const runId = faker.string.alphanumeric(8).toLowerCase();
+            const user = await prisma.user.create({
+                data: {
+                    email: `robots-${runId}@example.com`,
+                    password: 'hashed',
+                    firstName: 'Robots',
+                    lastName: 'Test',
+                },
+            });
+            profileUserId = user.id;
+
+            // Create a profile so the endpoint returns 200
+            await prisma.userProfile.create({ data: { userId: profileUserId } });
+
+            token = generateAccessToken({
+                username: user.email,
+                id: user.id,
+                index: faker.number.int({ min: 1, max: 999999 }),
+            }).token;
+        });
+
+        afterAll(async () => {
+            await prisma.userProfile.deleteMany({ where: { userId: profileUserId } });
+            await prisma.privacySettings.deleteMany({ where: { userId: profileUserId } });
+            await prisma.user.delete({ where: { id: profileUserId } });
+        });
+
+        it('includes X-Robots-Tag: index, follow when searchEngineIndexing is true', async () => {
+            await prisma.privacySettings.create({
+                data: { userId: profileUserId, searchEngineIndexing: true },
+            });
+
+            const res = await request(app)
+                .get(`/api/profile/${profileUserId}/public`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.headers['x-robots-tag']).toBe('index, follow');
+        });
+
+        it('includes X-Robots-Tag: noindex, nofollow when searchEngineIndexing is false', async () => {
+            await prisma.privacySettings.upsert({
+                where: { userId: profileUserId },
+                update: { searchEngineIndexing: false },
+                create: { userId: profileUserId, searchEngineIndexing: false },
+            });
+
+            const res = await request(app)
+                .get(`/api/profile/${profileUserId}/public`)
+                .set('Authorization', `Bearer ${token}`);
+
+            expect(res.status).toBe(200);
+            expect(res.headers['x-robots-tag']).toBe('noindex, nofollow');
+        });
+    });
+});


### PR DESCRIPTION
Closes #162, #163, #164

## What changed

**#162 – Data retention lifecycle (DataRetentionJob)**
Added `DataRetentionJob` with a `run()` batch method (nightly cron) and `enforceForUser()` for on-demand sweeps. Deletes audit logs, authored reviews, and sent tips older than the user's `dataRetentionMonths` cutoff. Emits an audit event when rows are removed.

**#163 – Privacy flag enforcement (PrivacyGuard)**
Added `PrivacyGuard` with typed guards for `searchEngineIndexing`, `allowDirectMessages`, and `allowProfileComments`. `getPublicProfile` now sets `X-Robots-Tag` based on the user's indexing preference. The two message/comment guards are ready to be called by those controllers as those features land.

**#164 – HTTP integration tests for export and deletion**
Added `data-export-http.test.ts` covering all 7 routes: auth enforcement, status codes, response envelopes, pagination, authorization isolation between users, and the full deletion lifecycle (schedule → duplicate guard → cancel in-app → cancel via email token → cross-user rejection).

## Tests added
- `src/services/__tests__/DataRetentionJob.test.ts` (7 tests)
- `src/services/__tests__/PrivacyGuard.test.ts` (12 tests)
- `src/controllers/__tests__/data-export-http.test.ts` (28 tests)
- 

closes #162
closes #163
closes #164 